### PR TITLE
Fix documentation about PIX header for non-retail XBOX builds

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -638,7 +638,11 @@ When using WinPixEventRuntime version 1.0.210209001:
 
   #if defined(USE_PIX) || !defined(PIX_XBOX)
   #define PIX_CONTEXT_EMIT_CPU_EVENTS
+  #endif
+  
+  #ifndef PIX_XBOX
   #include "AmdDxExt\AmdPix3.h"
+  #define PIX_AMD_EXT
   #endif
 
 When using WinPixEventRuntime version 1.0.200127001:
@@ -659,22 +663,31 @@ When using WinPixEventRuntime version 1.0.210209001:
 ::
 
   #ifdef PIX_CONTEXT_EMIT_CPU_EVENTS
-    // PIXBeginEventOnContextCpu(context, color, formatString, args...);
+  #ifdef PIX_AMD_EXT
     RgpPIXBeginEventOnContextCpu(context, color, formatString, args...);
+  #else
+    PIXBeginEventOnContextCpu(context, color, formatString, args...);
+  #endif
   #endif
 
 ::
 
   #ifdef PIX_CONTEXT_EMIT_CPU_EVENTS
-    // PIXSetMarkerOnContextCpu(context, color, formatString, args...);
+  #ifdef PIX_AMD_EXT
     RgpPIXSetMarkerOnContextCpu(context, color, formatString, args...);
+  #else
+    PIXSetMarkerOnContextCpu(context, color, formatString, args...);
+  #endif
   #endif
 
 ::
 
   #ifdef PIX_CONTEXT_EMIT_CPU_EVENTS
-    // PIXEndEventOnContextCpu(context);
+  #ifdef PIX_AMD_EXT
     RgpPIXEndEventOnContextCpu(context);
+  #else
+    PIXEndEventOnContextCpu(context);
+  #endif
   #endif
 
 When using WinPixEventRuntime version 1.0.200127001:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -637,13 +637,13 @@ When using WinPixEventRuntime version 1.0.210209001:
 ::
 
   #if defined(USE_PIX) || !defined(PIX_XBOX)
-  #define PIX_CONTEXT_EMIT_CPU_EVENTS
-  #endif
+    #define PIX_CONTEXT_EMIT_CPU_EVENTS
   
-  #ifndef PIX_XBOX
-  #include "AmdDxExt\AmdPix3.h"
-  #define PIX_AMD_EXT
-  #endif
+    #ifndef PIX_XBOX
+      #include "AmdDxExt\AmdPix3.h"
+      #define PIX_AMD_EXT
+    #endif
+  #endif  
 
 When using WinPixEventRuntime version 1.0.200127001:
 ::


### PR DESCRIPTION
AMDDxExt should probably always be disabled on XBOX, which is currently not the case when defining USE_PIX. This proposal disables the extension entirely, and allow fallback to the standard PIX functions.